### PR TITLE
Choose device based on macro

### DIFF
--- a/forte_config.h.in
+++ b/forte_config.h.in
@@ -55,6 +55,9 @@ const unsigned int cgIPLayerRecvBufferSize = ${FORTE_IPLayerRecvBufferSize};
 //! Max supported hierarchy that can be provided in a management commands
 #define FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY   ${FORTE_MGM_MAX_SUPPORTED_NAME_HIERACHY}
 
+#define FORTE_DEVICE ${FORTE_DEVICE}
+#define FORTE_DEVICE_INCLUDE "${FORTE_DEVICE}.h"
+
 /*! \brief FORTE string dict's initial string buffer size
  * 
  * Depending on the FORTE_STRING_DICT_FIXED_MEMORY flag the string dict will reallocate if necessary.

--- a/forte_config.h.in
+++ b/forte_config.h.in
@@ -55,9 +55,6 @@ const unsigned int cgIPLayerRecvBufferSize = ${FORTE_IPLayerRecvBufferSize};
 //! Max supported hierarchy that can be provided in a management commands
 #define FORTE_MGM_MAX_SUPPORTED_NAME_HIERARCHY   ${FORTE_MGM_MAX_SUPPORTED_NAME_HIERACHY}
 
-#define FORTE_DEVICE ${FORTE_DEVICE}
-#define FORTE_DEVICE_INCLUDE "${FORTE_DEVICE}.h"
-
 /*! \brief FORTE string dict's initial string buffer size
  * 
  * Depending on the FORTE_STRING_DICT_FIXED_MEMORY flag the string dict will reallocate if necessary.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,7 +268,6 @@ GET_PROPERTY(devices GLOBAL PROPERTY FORTE_DEVICES)
 list(SORT devices)
 set_property(CACHE FORTE_DEVICE PROPERTY STRINGS None ${devices})
 
-
 #######################################################################################
 # Link Libraries to the Executable
 #######################################################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,6 +268,8 @@ GET_PROPERTY(devices GLOBAL PROPERTY FORTE_DEVICES)
 list(SORT devices)
 set_property(CACHE FORTE_DEVICE PROPERTY STRINGS None ${devices})
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/forte_device_config.h.in ${CMAKE_BINARY_DIR}/forte_device_config.h)
+
 #######################################################################################
 # Link Libraries to the Executable
 #######################################################################################

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -17,7 +17,7 @@
 #include "ecet.h"
 #include <string.h>
 
-#include FORTE_DEVICE_INCLUDE
+#include "forte_device_config.h"
 
 std::unique_ptr<CDevice> CDevice::smActiveDevice;
 

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -17,7 +17,13 @@
 #include "ecet.h"
 #include <string.h>
 
+#include FORTE_DEVICE_INCLUDE
+
 std::unique_ptr<CDevice> CDevice::smActiveDevice;
+
+CDevice* CDevice::createDev(const std::string &paMGRID) {
+  return FORTE_DEVICE::createDev(paMGRID);
+}
 
 bool CDevice::startupNewDevice(const std::string &paMGRID){
   if(smActiveDevice){

--- a/src/forte_device_config.h.in
+++ b/src/forte_device_config.h.in
@@ -1,0 +1,4 @@
+#include "${FORTE_DEVICE}.h"
+
+using FORTE_DEVICE = ${FORTE_DEVICE};
+

--- a/src/stdfblib/ita/CMakeLists.txt
+++ b/src/stdfblib/ita/CMakeLists.txt
@@ -20,10 +20,6 @@ forte_add_sourcefile_hcpp(DEV_MGR  EMB_RES  RMT_DEV  RMT_RES)
 
 forte_add_device(RMT_DEV)
 
-if("${FORTE_DEVICE}" STREQUAL "RMT_DEV")
-  forte_add_sourcefile_hcpp(RMT_DEV)
-endif()
-
 if (FORTE_COM_OPC_UA)
   forte_add_sourcefile_hcpp(Config_EMB_RES)
   

--- a/src/stdfblib/ita/OPCUA_DEV.cpp
+++ b/src/stdfblib/ita/OPCUA_DEV.cpp
@@ -21,6 +21,15 @@ OPCUA_DEV::OPCUA_DEV() :
 OPCUA_DEV::~OPCUA_DEV() {
 }
 
+CDevice* OPCUA_DEV::createDev(const std::string &paMGRID) {
+  OPCUA_DEV *dev = new OPCUA_DEV;
+  dev->initialize();
+  if(paMGRID.length() != 0){
+    dev->setMGR_ID(paMGRID);
+  }
+  return dev;
+}
+
 int OPCUA_DEV::startDevice(void) {
   RMT_DEV::startDevice();
   if (mOPCUAMgr.initialize() != EMGMResponse::Ready) {

--- a/src/stdfblib/ita/OPCUA_DEV.h
+++ b/src/stdfblib/ita/OPCUA_DEV.h
@@ -24,5 +24,7 @@ public:
   OPCUA_DEV();
   virtual ~OPCUA_DEV();
 
+  static CDevice *createDev(const std::string &paMGRID);
+
   virtual int startDevice(void);
 };

--- a/src/stdfblib/ita/RMT_DEV.cpp
+++ b/src/stdfblib/ita/RMT_DEV.cpp
@@ -17,7 +17,7 @@
 #endif
 #include <stringdict.h>
 
-CDevice* CDevice::createDev(const std::string &paMGRID) {
+CDevice* RMT_DEV::createDev(const std::string &paMGRID) {
   RMT_DEV *dev = new RMT_DEV;
   dev->initialize();
   if(paMGRID.length() != 0){

--- a/src/stdfblib/ita/RMT_DEV.h
+++ b/src/stdfblib/ita/RMT_DEV.h
@@ -22,12 +22,14 @@
  */
 
 
- class RMT_DEV final : public CDevice{
+ class RMT_DEV : public CDevice{
   public:
     RMT_DEV();
     ~RMT_DEV() override;
 
     bool initialize() override;
+
+    static CDevice *createDev(const std::string &paMGRID);
 
   /*! \brief Adds additional functionality to the originals execute func of the device.
   *


### PR DESCRIPTION
This change chooses the device based on a macro instead of conditional compilation. It also works again with OPCUA_DEV.