### PR TITLE
Fix uninitialized FB interface spec in EMB_RES

### DIFF
--- a/src/stdfblib/ita/EMB_RES.cpp
+++ b/src/stdfblib/ita/EMB_RES.cpp
@@ -29,7 +29,7 @@ const SFBInterfaceSpec EMB_RES::scmFBInterfaceSpec = {
 };
 
 EMB_RES::EMB_RES(CStringDictionary::TStringId paInstanceNameId, forte::core::CFBContainer &paDevice) :
-    CResource(paDevice, nullptr, paInstanceNameId){
+    CResource(paDevice, &scmFBInterfaceSpec, paInstanceNameId){
 }
 
 bool EMB_RES::initialize() {


### PR DESCRIPTION
The uninitialized FB interface spec in EMB_RES caused an invalid nullptr access.